### PR TITLE
cmake: actually install header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,14 @@ if (RAPIDXML_INSTALL)
           PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/rapidxml"
           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+  # Install header files
+  install(FILES
+          rapidxml.hpp
+          rapidxml_iterators.hpp
+          rapidxml_print.hpp
+          rapidxml_utils.hpp
+          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rapidxml)
+
   # Use a namespace because CMake provides better diagnostics for namespaced
   # imported targets.
   export(TARGETS ${INSTALL_TARGETS} NAMESPACE rapidxml::


### PR DESCRIPTION
This fixes the install by actually copying the header files to the install destination.

I'm testing with these commands:

```
cmake -Bbuild -DCMAKE_INSTALL_PREFIX=install -DRAPIDXML_INSTALL=ON -S.
cmake --build build --target install
```

Current master:

```
Install the project...
-- Install configuration: ""
-- Installing: /home/julianoes/src/other/rapidxml/install/lib/cmake/rapidxml/rapidxml-config.cmake
-- Installing: /home/julianoes/src/other/rapidxml/install/lib/cmake/rapidxml/rapidxml-config-version.cmake
-- Installing: /home/julianoes/src/other/rapidxml/install/lib/cmake/rapidxml/rapidxml-targets.cmake
```

With this PR:

```
-- Installing: /home/julianoes/src/other/rapidxml/install/include/rapidxml/rapidxml.hpp
-- Installing: /home/julianoes/src/other/rapidxml/install/include/rapidxml/rapidxml_iterators.hpp
-- Installing: /home/julianoes/src/other/rapidxml/install/include/rapidxml/rapidxml_print.hpp
-- Installing: /home/julianoes/src/other/rapidxml/install/include/rapidxml/rapidxml_utils.hpp
-- Installing: /home/julianoes/src/other/rapidxml/install/lib/cmake/rapidxml/rapidxml-config.cmake
-- Installing: /home/julianoes/src/other/rapidxml/install/lib/cmake/rapidxml/rapidxml-config-version.cmake
-- Installing: /home/julianoes/src/other/rapidxml/install/lib/cmake/rapidxml/rapidxml-targets.cmake
```