### PR TITLE
Fix MSVC 2022 compilation with /permissive mode

### DIFF
--- a/rapidxml.hpp
+++ b/rapidxml.hpp
@@ -411,8 +411,8 @@ namespace rapidxml
     public:
 
         //! \cond internal
-        typedef void *(alloc_func)(std::size_t);       // Type of user-defined function used to allocate memory
-        typedef void (free_func)(void *);              // Type of user-defined function used to free memory
+        typedef void *(*alloc_func)(std::size_t);       // Type of user-defined function used to allocate memory
+        typedef void (*free_func)(void *);              // Type of user-defined function used to free memory
         //! \endcond
 
         //! Constructs empty pool with default allocator functions.
@@ -578,7 +578,7 @@ namespace rapidxml
         //! </code><br>
         //! \param af Allocation function, or 0 to restore default function
         //! \param ff Free function, or 0 to restore default function
-        void set_allocator(alloc_func *af, free_func *ff)
+        void set_allocator(alloc_func af, free_func ff)
         {
             assert(m_begin == m_static_memory && m_ptr == align(m_begin));    // Verify that no memory is allocated yet
             m_alloc_func = af;
@@ -663,8 +663,8 @@ namespace rapidxml
         char *m_ptr;                                        // First free byte in current pool
         char *m_end;                                        // One past last available byte in current pool
         char m_static_memory[RAPIDXML_STATIC_POOL_SIZE];    // Static raw memory
-        alloc_func *m_alloc_func;                           // Allocator function, or 0 if default is to be used
-        free_func *m_free_func;                             // Free function, or 0 if default is to be used
+        alloc_func m_alloc_func;                           // Allocator function, or 0 if default is to be used
+        free_func m_free_func;                             // Free function, or 0 if default is to be used
     };
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Problem

RapidXML 1.13 fails to compile with Visual Studio 2022 when using \ or \ strict conformance mode:

\
## Root Cause

Lines 411-412 use function type syntax instead of function pointer syntax for typedefs, which is rejected by modern MSVC in strict conformance mode.

## Solution

Changed function type typedefs to function pointer typedefs in 4 locations:

**Lines 411-412**: Type definitions
\
**Line 578**: Function parameter
\
**Lines 663-664**: Member variables
\
## Testing

✅ Compiles successfully with MSVC 2022 (14.44) \ mode
✅ No behavior changes (ABI compatible)
✅ Tested in production (VC6 → VS2022 migration project)
✅ Used to replace Xerces-C in legacy trading application

## Compatibility

| Compiler | Status |
|----------|--------|
| **Visual Studio 2022** | ✅ **Fixed** |
| **Visual Studio 2019** with \ | ✅ **Fixed** |
| Visual Studio 2017 and older | ✅ Compatible (no changes needed) |
| GCC / Clang | ✅ Compatible (both syntaxes accepted) |

## Reference

Complete fork with fixes and documentation: https://github.com/ivosetyadi/rapidxml-msvc2022